### PR TITLE
add app_id propagation

### DIFF
--- a/cmd/ucl-launcher/ucl_launcher.go
+++ b/cmd/ucl-launcher/ucl_launcher.go
@@ -46,6 +46,7 @@ type frontendParams_t struct {
 
 type backendParams_t struct {
 	IviSurfaceId       *int   `json:"ivi_surface_id"`
+	AppId              string `json:"app_id"`
 	ScanOutX           int    `json:"scanout_x"`
 	ScanOutY           int    `json:"scanout_y"`
 	ScanOutW           int    `json:"scanout_w"`
@@ -172,6 +173,10 @@ func makeReceiverCmdParams(uclComm uclCommand, makeParam string, r receiver_t) s
 
 	if rparam.IviSurfaceId != nil {
 		makeParam = makeParam + " -S " + strconv.Itoa(*rparam.IviSurfaceId)
+	}
+
+	if rparam.AppId != "" {
+		makeParam = makeParam + " -a " + rparam.AppId
 	}
 
 	return makeParam

--- a/cmd/ucl-virtio-gpu-wl-recv/ucl_virtio_gpu_wl_recv.go
+++ b/cmd/ucl-virtio-gpu-wl-recv/ucl_virtio_gpu_wl_recv.go
@@ -52,6 +52,7 @@ func main() {
 		screen       string
 		port         string
 		initialColor string
+		appId        string
 	)
 
 	flag.BoolVar(&verbose, "v", true, "verbose info log")
@@ -61,6 +62,7 @@ func main() {
 	flag.StringVar(&screen, "s", "1920x1080@0,0", "remote-virtio-gpu reciever screen config")
 	flag.StringVar(&port, "P", "55667", "specify remote-virtio-gpu reciever port")
 	flag.StringVar(&initialColor, "B", "0x33333333", "remote-virtio-gpu reciever color config")
+	flag.StringVar(&appId, "a", "", "remote-virtio-gpu reciever application id")
 	flag.Parse()
 
 	xdgRuntimeDir := ucl.GetEnv("XDG_RUNTIME_DIR", "/run/user/1000")
@@ -97,6 +99,11 @@ func main() {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
+	if appId != "" {
+		env_app_id := "XDG_TOPLEVEL_FALLBACK_APP_ID=" + appId
+		cmd.Env = append(cmd.Env, env_app_id)
+	}
 
 	err = cmd.Start()
 	if err != nil {


### PR DESCRIPTION
When app_id is set in app.json, ucl-launcher can retrieve it and transfer to the ucl-virtio-gpu-wl-recv.
Then, it set XDG_TOPLEVEL_FALLBACK_APP_ID=app_id as an environment variable, which rvgpu-renderer can read.